### PR TITLE
Update parser_api.proto

### DIFF
--- a/src/main/java/com/wine/to/up/parser/common/api/schema/parser_api.proto
+++ b/src/main/java/com/wine/to/up/parser/common/api/schema/parser_api.proto
@@ -25,7 +25,7 @@ message Wine {
   Sugar sugar = 7;
   float old_price = 8;
   float new_price = 21;
-  string image = 9;
+  byte[] image = 9;
   string manufacturer = 11;
   repeated string region = 12;
   string link = 13;


### PR DESCRIPTION
Как и договаривались с командой БА, картинка должна храниться как картинка, т.е. в байтовом массиве.
На стороне сервиса мы сейчас кодируем байтовый массив в строку для передачи в кафку, чего не должно быть.